### PR TITLE
Add Docker setup and health-check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/powershell:4-powershell7.2-appservice
+# Use the official Azure Functions v4 PowerShell image as the base
 FROM mcr.microsoft.com/azure-functions/powershell:4-powershell7.2
+
+# Configure the function app's root and enable console logging
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
+# Copy the Azure Functions project into the container
 COPY . /home/site/wwwroot
+
+# Azure Functions listens on port 80 by default
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# CIPP-API Docker Setup
+
+This repository provides Docker assets to run the existing **CIPP-API** Azure Functions
+application on any server without Azure dependencies. The stack uses the official
+Azure Functions v4 PowerShell image and the Azurite storage emulator.
+
+## Services
+
+The supplied `docker-compose.yml` starts three containers:
+
+- **azurite** – local Azure Storage emulator (blob, queue, table) on ports `10000-10002`.
+- **cippapi** – Azure Functions host running the CIPP-API code.
+- **nginx** – reverse proxy exposing the Functions host on `http://localhost:7071`.
+
+A simple health-check endpoint is available at `GET /upmon` and returns `200 OK`.
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/) and Docker Compose.
+- Environment variables for the Function app configuration. Create a `.env` file
+  in the repository root and supply the following keys:
+
+```
+FUNCTIONS_WORKER_RUNTIME=
+FUNCTIONS_WORKER_RUNTIME_VERSION=
+AzureWebJobsStorage=
+ApplicationID=
+ApplicationSecret=
+RefreshToken=
+TenantID=
+DEV_SKIP_BPA_TIMER=
+DEV_SKIP_DOMAIN_TIMER=
+SetFromProfile=
+FUNCTIONS_EXTENSION_VERSION=
+```
+
+Values remain unchanged from the original implementation. Secrets should be
+managed according to your security practices.
+
+## Usage
+
+Build and start the stack:
+
+```bash
+docker compose up --build
+```
+
+The API will be available at [http://localhost:7071](http://localhost:7071).
+Verify availability via the health-check endpoint:
+
+```bash
+curl http://localhost:7071/upmon
+```
+
+Logs from the Functions runtime are written to stdout. Azurite and Nginx use
+their default logging behavior.
+
+## Notes
+
+These Docker assets are intended for local development or testing. Production
+hardening (TLS, scaling, secure secret storage) is outside the scope of this
+setup.
+

--- a/UpmonFunction/function.json
+++ b/UpmonFunction/function.json
@@ -1,0 +1,18 @@
+{
+  "scriptFile": "run.ps1",
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": ["get"],
+      "route": "upmon"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    }
+  ]
+}

--- a/UpmonFunction/run.ps1
+++ b/UpmonFunction/run.ps1
@@ -1,0 +1,10 @@
+param($Request, $TriggerMetadata)
+
+# UpmonFunction
+# Simple health-check endpoint for the API.
+# Returns HTTP 200 to confirm the service is running.
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = 200
+    Body       = "OK"
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,25 @@
 services:
   azurite:
+    # Local Azure Storage emulator providing blob, queue, and table services
     image: mcr.microsoft.com/azure-storage/azurite
     container_name: azurite
     ports:
-      - "10000:10000"
-      - "10001:10001"
-      - "10002:10002"
+      - "10000:10000" # Blob service
+      - "10001:10001" # Queue service
+      - "10002:10002" # Table service
     networks:
       - func-network
     environment:
       - AZURITE_ACCOUNTS=devstoreaccount1:Eby8vdM02xNoBnZf6KgBVU4=
 
   cippapi:
+    # Azure Functions host running the CIPP API
     build:
       context: .
       dockerfile: Dockerfile
     environment:
+      # Configuration values are passed through environment variables.
+      # These names match the existing implementation.
       - FUNCTIONS_WORKER_RUNTIME=${FUNCTIONS_WORKER_RUNTIME}
       - FUNCTIONS_WORKER_RUNTIME_VERSION=${FUNCTIONS_WORKER_RUNTIME_VERSION}
       - AzureWebJobsStorage=${AzureWebJobsStorage}
@@ -38,10 +42,11 @@ services:
       replicas: 3
 
   nginx:
+    # Reverse proxy exposing the Functions host on a standard port
     image: nginx:alpine
     container_name: nginx
     ports:
-      - "7071:80"
+      - "7071:80" # API available on localhost:7071
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
@@ -49,7 +54,7 @@ services:
     networks:
       - func-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://cippapi:7071"]
+      test: ["CMD", "curl", "-f", "http://cippapi:80/upmon"]
       interval: 30s
       retries: 5
 


### PR DESCRIPTION
## Summary
- create UpmonFunction health endpoint for simple availability checks
- document and comment Dockerfile and docker-compose setup
- add README with instructions for running CIPP-API via Docker

## Testing
- `docker compose config -q` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -Command "Test-Path UpmonFunction/run.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4aec9cd14832e949d6d42d4ec8462